### PR TITLE
Add #[cfg(test)]

### DIFF
--- a/src/bellman_ford.rs
+++ b/src/bellman_ford.rs
@@ -33,6 +33,7 @@ pub fn shortest_path(start: usize, num_of_vertexes: usize, edges: &Vec<Edge>) ->
     dists
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -66,6 +66,7 @@ pub fn shortest_path(adj_list: &Vec<Vec<Edge>>, start: usize) -> Vec<usize> {
     dist
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/src/prim.rs
+++ b/src/prim.rs
@@ -65,6 +65,7 @@ pub fn shortest_path(adj_list: &Vec<Vec<Edge>>, start: usize) -> isize {
     res
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/src/union_find_tree.rs
+++ b/src/union_find_tree.rs
@@ -52,6 +52,7 @@ impl UnionFindTree {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::UnionFindTree;
 

--- a/src/warshall_floyd.rs
+++ b/src/warshall_floyd.rs
@@ -10,6 +10,7 @@ pub fn warshall_floyd(num_of_vertexes: usize, dists: &mut Vec<Vec<isize>>) {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
 


### PR DESCRIPTION
Without this, we'll see the  **warning: unused import: `super::*`**